### PR TITLE
correcting spelling mistake in license header + keep folder 'test/'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ log
 .project
 .settings
 test/*
-!test/.gitkeep
+!*.gitkeep/
 **/Thumbs.db
 nbactions.xml

--- a/misc/license_header.txt
+++ b/misc/license_header.txt
@@ -18,7 +18,7 @@ library is not considered a "derivative work" of the program:
 Therefore the distribution of the program linked with libraries licensed
 under the aforementioned licenses, is permitted by the copyright holders
 if the distribution is compliant with both the GNU General Public
-icense version 2 and the aforementioned licenses.
+License version 2 and the aforementioned licenses.
 
 This program is distributed in the hope that it will be useful, but
 WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/importtools/Country.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/importtools/Country.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/importtools/CountryIsoCodeMapGenerator.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/importtools/CountryIsoCodeMapGenerator.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/importtools/CsvImporter.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/importtools/CsvImporter.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/importtools/DatasetEntry.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/importtools/DatasetEntry.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/importtools/Importer.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/importtools/Importer.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/importtools/KeyValuePair.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/importtools/KeyValuePair.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/load/DatasetLoader.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/load/DatasetLoader.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/AbstractXmlDataset.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/AbstractXmlDataset.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/XmlBitmapDataset.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/XmlBitmapDataset.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/XmlCountryCodeDataset.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/XmlCountryCodeDataset.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/XmlDataset.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/XmlDataset.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/XmlEsriShapeDataset.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/XmlEsriShapeDataset.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/XmlPointDataset.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/XmlPointDataset.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/AbstractShapeReader.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/AbstractShapeReader.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/BoundingBoxExtractor.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/BoundingBoxExtractor.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/GeoReferenceFeatureTypeEnum.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/GeoReferenceFeatureTypeEnum.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/GeometryConverter.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/GeometryConverter.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/JTSHelper.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/JTSHelper.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/ShapeReader.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/ShapeReader.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/ShapeReader_Detailed.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/ShapeReader_Detailed.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/ShapeReader_Simplified_110m.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/ShapeReader_Simplified_110m.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/ShapeReader_Simplified_50m.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/ShapeReader_Simplified_50m.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/Unit.java
+++ b/src/main/java/org/n52/v3d/worldviz/dataaccess/load/dataset/helper/Unit.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/CoordinateTransformDemo.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/CoordinateTransformDemo.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/FeatureNetInterface.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/FeatureNetInterface.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/FeatureNetTest.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/FeatureNetTest.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/FeatureNetTestGUI.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/FeatureNetTestGUI.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/FeatureNetTest_CSV.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/FeatureNetTest_CSV.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/HelloWorldViz.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/HelloWorldViz.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/MappersDemo.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/MappersDemo.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/connectionmaps/PajekReaderApp.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/connectionmaps/PajekReaderApp.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_CO2Emission.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_CO2Emission.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_CO2EmissionsPerCapita.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_CO2EmissionsPerCapita.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_CountryCodes.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_CountryCodes.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_CountryCodes_simplified_110m.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_CountryCodes_simplified_110m.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_CountryCodes_simplified_50m.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_CountryCodes_simplified_50m.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_ElectricityAccess.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_ElectricityAccess.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_ElectricityConsumption.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_ElectricityConsumption.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_ElectricityExport.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_ElectricityExport.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_ElectricityGeneration.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_ElectricityGeneration.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_ElectricityImport.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_ElectricityImport.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_ElectricityProductionFromSpecificRessource.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_ElectricityProductionFromSpecificRessource.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_GasResources.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_GasResources.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_HardCoal.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_HardCoal.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_NuclearAccidents.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_NuclearAccidents.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_OilResources.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_OilResources.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_Population.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_Population.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_SoftLignite.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/datageneration/FillDataset_SoftLignite.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/AccessToElectricity.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/AccessToElectricity.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/AccessToElectricity_flat2D.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/AccessToElectricity_flat2D.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/CarbonEmissionsPerCapita_average.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/CarbonEmissionsPerCapita_average.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/CarbonEmissions_ExtrusionTest.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/CarbonEmissions_ExtrusionTest.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/CarbonEmissions_finer.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/CarbonEmissions_finer.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/CartographicSymbolsTest.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/CartographicSymbolsTest.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/CartographicSymbolsTest2.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/CartographicSymbolsTest2.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/ColoredWorldCountriesScene.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/ColoredWorldCountriesScene.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/DrapedWorldSphere.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/DrapedWorldSphere.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/DrapedWorldSphere_withVgElevationGrid.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/DrapedWorldSphere_withVgElevationGrid.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/PetersProjektionTest.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/PetersProjektionTest.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/ToBuckmFullerTest.java
+++ b/src/main/java/org/n52/v3d/worldviz/demoapplications/ene/earth/ToBuckmFullerTest.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/exception/NoValidFeatureTypeException.java
+++ b/src/main/java/org/n52/v3d/worldviz/exception/NoValidFeatureTypeException.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/exception/ShapeGeometryNotFoundException.java
+++ b/src/main/java/org/n52/v3d/worldviz/exception/ShapeGeometryNotFoundException.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/exception/UnknownCountryCodeCrsException.java
+++ b/src/main/java/org/n52/v3d/worldviz/exception/UnknownCountryCodeCrsException.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/exception/UnmatchingEntryPropertyArrayException.java
+++ b/src/main/java/org/n52/v3d/worldviz/exception/UnmatchingEntryPropertyArrayException.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/extensions/GmLinearRing.java
+++ b/src/main/java/org/n52/v3d/worldviz/extensions/GmLinearRing.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/extensions/GmMultiPolygon.java
+++ b/src/main/java/org/n52/v3d/worldviz/extensions/GmMultiPolygon.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/extensions/GmPolygon.java
+++ b/src/main/java/org/n52/v3d/worldviz/extensions/GmPolygon.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/extensions/VgCollection2D.java
+++ b/src/main/java/org/n52/v3d/worldviz/extensions/VgCollection2D.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/extensions/VgLinearRing.java
+++ b/src/main/java/org/n52/v3d/worldviz/extensions/VgLinearRing.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/extensions/VgMultiPolygon.java
+++ b/src/main/java/org/n52/v3d/worldviz/extensions/VgMultiPolygon.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/extensions/VgPolygon.java
+++ b/src/main/java/org/n52/v3d/worldviz/extensions/VgPolygon.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/extensions/mappers/AttributeValuePair.java
+++ b/src/main/java/org/n52/v3d/worldviz/extensions/mappers/AttributeValuePair.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/extensions/mappers/MpAttrFeature2AttrSymbol.java
+++ b/src/main/java/org/n52/v3d/worldviz/extensions/mappers/MpAttrFeature2AttrSymbol.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/extensions/mappers/MpValue2ColoredAttrFeature.java
+++ b/src/main/java/org/n52/v3d/worldviz/extensions/mappers/MpValue2ColoredAttrFeature.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/extensions/mappers/MpValue2ColoredSymbol.java
+++ b/src/main/java/org/n52/v3d/worldviz/extensions/mappers/MpValue2ColoredSymbol.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/extensions/mappers/MpValue2ExtrudedAttrFeature.java
+++ b/src/main/java/org/n52/v3d/worldviz/extensions/mappers/MpValue2ExtrudedAttrFeature.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/extensions/mappers/MpValue2NumericExtent.java
+++ b/src/main/java/org/n52/v3d/worldviz/extensions/mappers/MpValue2NumericExtent.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/extensions/mappers/MpValue2ScaledSymbol.java
+++ b/src/main/java/org/n52/v3d/worldviz/extensions/mappers/MpValue2ScaledSymbol.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/extensions/mappers/NamesForAttributes.java
+++ b/src/main/java/org/n52/v3d/worldviz/extensions/mappers/NamesForAttributes.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/extensions/mappers/T3dAttrSymbolInstance.java
+++ b/src/main/java/org/n52/v3d/worldviz/extensions/mappers/T3dAttrSymbolInstance.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/VgFeatureNet.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/VgFeatureNet.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/VgRelation.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/VgRelation.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/impl/Arc.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/impl/Arc.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/impl/CsvReaderForConnectionMap.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/impl/CsvReaderForConnectionMap.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/impl/Edge.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/impl/Edge.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/impl/FileIO.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/impl/FileIO.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/impl/PajekReader.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/impl/PajekReader.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/impl/Parse.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/impl/Parse.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/impl/PrettyPrint.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/impl/PrettyPrint.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/impl/Vector.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/impl/Vector.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/impl/Vertex.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/impl/Vertex.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/impl/WvizArc.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/impl/WvizArc.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/impl/WvizConnection.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/impl/WvizConnection.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/impl/WvizFlow.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/impl/WvizFlow.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/impl/WvizFlowNet.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/impl/WvizFlowNet.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/impl/WvizUniversalFeatureNet.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/impl/WvizUniversalFeatureNet.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/impl/X3DScene.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/impl/X3DScene.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/scene/AbstractSceneSymbolTransformer.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/scene/AbstractSceneSymbolTransformer.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/scene/MpFeatureNetVisualizer.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/scene/MpFeatureNetVisualizer.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/scene/MprConnectionMapGenerator.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/scene/MprConnectionMapGenerator.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/scene/SceneSymbolTransformer.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/scene/SceneSymbolTransformer.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/scene/SceneSymbolTransformer_CurvedConnections.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/scene/SceneSymbolTransformer_CurvedConnections.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/scene/SceneSymbolTransformer_StraightConnections.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/scene/SceneSymbolTransformer_StraightConnections.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/scene/WvizConcreteConnectionMapScene.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/scene/WvizConcreteConnectionMapScene.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/scene/WvizConnectionMapSceneKml.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/scene/WvizConnectionMapSceneKml.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/scene/WvizConnectionMapSceneX3d.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/scene/WvizConnectionMapSceneX3d.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/scene/WvizConnectionMapSceneX3d_earlier.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/scene/WvizConnectionMapSceneX3d_earlier.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/scene/WvizVirtualConnectionMapScene.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/scene/WvizVirtualConnectionMapScene.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/shapes/Circle.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/shapes/Circle.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/shapes/Curve.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/shapes/Curve.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/shapes/Ellipse.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/shapes/Ellipse.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/shapes/Ribbon.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/shapes/Ribbon.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Background.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Background.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/BackgroundWorldMap.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/BackgroundWorldMap.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/ColorEntry.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/ColorEntry.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/ColorMapper.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/ColorMapper.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/ColorPalette.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/ColorPalette.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/ConnectionNet.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/ConnectionNet.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Displacement.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Displacement.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Features.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Features.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Fill.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Fill.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Font.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Font.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Geometry.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Geometry.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/InterpolationMode.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/InterpolationMode.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Label.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Label.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/LabelPlacement.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/LabelPlacement.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/LineVisualizer.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/LineVisualizer.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Mapper.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Mapper.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/OutputColor.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/OutputColor.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/PointPlacement.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/PointPlacement.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/PointVisualizer.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/PointVisualizer.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Relations.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Relations.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/SvgParameter.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/SvgParameter.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/T3dSymbol.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/T3dSymbol.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/TextVisualizer.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/TextVisualizer.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Viewpoint.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/Viewpoint.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/WidthEntry.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/WidthEntry.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/WidthMapper.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/WidthMapper.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/WidthPalette.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/WidthPalette.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/WvizConfig.java
+++ b/src/main/java/org/n52/v3d/worldviz/featurenet/xstream/WvizConfig.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/helper/FileHelper.java
+++ b/src/main/java/org/n52/v3d/worldviz/helper/FileHelper.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/helper/RelativePaths.java
+++ b/src/main/java/org/n52/v3d/worldviz/helper/RelativePaths.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/projections/AxisSwitchTransform.java
+++ b/src/main/java/org/n52/v3d/worldviz/projections/AxisSwitchTransform.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/projections/ChainedTransform.java
+++ b/src/main/java/org/n52/v3d/worldviz/projections/ChainedTransform.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/projections/CoordinateTransform.java
+++ b/src/main/java/org/n52/v3d/worldviz/projections/CoordinateTransform.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/projections/NormTransform.java
+++ b/src/main/java/org/n52/v3d/worldviz/projections/NormTransform.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/projections/NormTransform_Wgs84.java
+++ b/src/main/java/org/n52/v3d/worldviz/projections/NormTransform_Wgs84.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/projections/RotationTransform.java
+++ b/src/main/java/org/n52/v3d/worldviz/projections/RotationTransform.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/projections/ScaleTransform.java
+++ b/src/main/java/org/n52/v3d/worldviz/projections/ScaleTransform.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/projections/TranslationTransform.java
+++ b/src/main/java/org/n52/v3d/worldviz/projections/TranslationTransform.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/projections/Wgs84ToDymaxionTransform.java
+++ b/src/main/java/org/n52/v3d/worldviz/projections/Wgs84ToDymaxionTransform.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/projections/Wgs84ToPetersTransform.java
+++ b/src/main/java/org/n52/v3d/worldviz/projections/Wgs84ToPetersTransform.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/projections/Wgs84ToSphereCoordsTransform.java
+++ b/src/main/java/org/n52/v3d/worldviz/projections/Wgs84ToSphereCoordsTransform.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/projections/Wgs84ToX3DTransform.java
+++ b/src/main/java/org/n52/v3d/worldviz/projections/Wgs84ToX3DTransform.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/projections/dymaxion/InfoObj.java
+++ b/src/main/java/org/n52/v3d/worldviz/projections/dymaxion/InfoObj.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/projections/dymaxion/Point2D.java
+++ b/src/main/java/org/n52/v3d/worldviz/projections/dymaxion/Point2D.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/projections/dymaxion/Point3D.java
+++ b/src/main/java/org/n52/v3d/worldviz/projections/dymaxion/Point3D.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/projections/dymaxion/PointLatLon.java
+++ b/src/main/java/org/n52/v3d/worldviz/projections/dymaxion/PointLatLon.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/projections/dymaxion/PointPolar.java
+++ b/src/main/java/org/n52/v3d/worldviz/projections/dymaxion/PointPolar.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/projections/dymaxion/Transformator.java
+++ b/src/main/java/org/n52/v3d/worldviz/projections/dymaxion/Transformator.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/triangulation/InnerPointsForPolygonClass.java
+++ b/src/main/java/org/n52/v3d/worldviz/triangulation/InnerPointsForPolygonClass.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/triangulation/PolygonTriangulator.java
+++ b/src/main/java/org/n52/v3d/worldviz/triangulation/PolygonTriangulator.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/worldscene/OutputFormatEnum.java
+++ b/src/main/java/org/n52/v3d/worldviz/worldscene/OutputFormatEnum.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/worldscene/VsAbstractWorldScene.java
+++ b/src/main/java/org/n52/v3d/worldviz/worldscene/VsAbstractWorldScene.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/worldscene/VsCartographicSymbolsOnASphereScene.java
+++ b/src/main/java/org/n52/v3d/worldviz/worldscene/VsCartographicSymbolsOnASphereScene.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/worldscene/VsCartographicSymbolsScene.java
+++ b/src/main/java/org/n52/v3d/worldviz/worldscene/VsCartographicSymbolsScene.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/worldscene/VsDrapedWorldSphereScene.java
+++ b/src/main/java/org/n52/v3d/worldviz/worldscene/VsDrapedWorldSphereScene.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/worldscene/VsWorldCountriesOnASphereScene.java
+++ b/src/main/java/org/n52/v3d/worldviz/worldscene/VsWorldCountriesOnASphereScene.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/worldscene/VsWorldCountriesScene.java
+++ b/src/main/java/org/n52/v3d/worldviz/worldscene/VsWorldCountriesScene.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/worldscene/helper/AbstractGeneratorForMapOfAllCountries.java
+++ b/src/main/java/org/n52/v3d/worldviz/worldscene/helper/AbstractGeneratorForMapOfAllCountries.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/worldscene/helper/CountryBordersLODEnum.java
+++ b/src/main/java/org/n52/v3d/worldviz/worldscene/helper/CountryBordersLODEnum.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/worldscene/helper/FindExtrudeAndColorMissingCountriesHelper.java
+++ b/src/main/java/org/n52/v3d/worldviz/worldscene/helper/FindExtrudeAndColorMissingCountriesHelper.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/worldscene/helper/GeneratorForMapOfAllCountries.java
+++ b/src/main/java/org/n52/v3d/worldviz/worldscene/helper/GeneratorForMapOfAllCountries.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/worldscene/helper/GeneratorForMapOfAllCountries_detailed.java
+++ b/src/main/java/org/n52/v3d/worldviz/worldscene/helper/GeneratorForMapOfAllCountries_detailed.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/worldscene/helper/GeneratorForMapOfAllCountries_simplified_110m.java
+++ b/src/main/java/org/n52/v3d/worldviz/worldscene/helper/GeneratorForMapOfAllCountries_simplified_110m.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/worldscene/helper/GeneratorForMapOfAllCountries_simplified_50m.java
+++ b/src/main/java/org/n52/v3d/worldviz/worldscene/helper/GeneratorForMapOfAllCountries_simplified_50m.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/java/org/n52/v3d/worldviz/worldscene/helper/NormalVectorHelper.java
+++ b/src/main/java/org/n52/v3d/worldviz/worldscene/helper/NormalVectorHelper.java
@@ -1,3 +1,31 @@
+/**
+ * Copyright (C) 2015-2015 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * If the program is linked with libraries which are licensed under one of
+ * the following licenses, the combination of the program with the linked
+ * library is not considered a "derivative work" of the program:
+ *
+ *  - Apache License, version 2.0
+ *  - Apache Software License, version 1.0
+ *  - GNU Lesser General Public License, version 3
+ *  - Mozilla Public License, versions 1.0, 1.1 and 2.0
+ *  - Common Development and Distribution License (CDDL), version 1.0.
+ *
+ * Therefore the distribution of the program linked with libraries licensed
+ * under the aforementioned licenses, is permitted by the copyright holders
+ * if the distribution is compliant with both the GNU General Public
+ * License version 2 and the aforementioned licenses.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ */
 package org.n52.v3d.worldviz.worldscene.helper;
 
 import org.n52.v3d.triturus.t3dutil.T3dVector;

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -21,7 +21,7 @@
     Therefore the distribution of the program linked with libraries licensed
     under the aforementioned licenses, is permitted by the copyright holders
     if the distribution is compliant with both the GNU General Public
-    icense version 2 and the aforementioned licenses.
+    License version 2 and the aforementioned licenses.
 
     This program is distributed in the hope that it will be useful, but
     WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/test/java/org/n52/v3d/worldviz/test/CsvReaderForConnectionMap_Test.java
+++ b/src/test/java/org/n52/v3d/worldviz/test/CsvReaderForConnectionMap_Test.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/test/java/org/n52/v3d/worldviz/test/DatasetLoader_Test.java
+++ b/src/test/java/org/n52/v3d/worldviz/test/DatasetLoader_Test.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/test/java/org/n52/v3d/worldviz/test/PajekReader_Test.java
+++ b/src/test/java/org/n52/v3d/worldviz/test/PajekReader_Test.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/test/java/org/n52/v3d/worldviz/test/Triangulation_Test.java
+++ b/src/test/java/org/n52/v3d/worldviz/test/Triangulation_Test.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/test/java/org/n52/v3d/worldviz/test/WvizConfig_Test.java
+++ b/src/test/java/org/n52/v3d/worldviz/test/WvizConfig_Test.java
@@ -19,7 +19,7 @@
  * Therefore the distribution of the program linked with libraries licensed
  * under the aforementioned licenses, is permitted by the copyright holders
  * if the distribution is compliant with both the GNU General Public
- * icense version 2 and the aforementioned licenses.
+ * License version 2 and the aforementioned licenses.
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
right now executable test files depend on the test-folder as output-folder for scene generation.